### PR TITLE
context: add timestanp to block query result 

### DIFF
--- a/src/xchain/block.cc
+++ b/src/xchain/block.cc
@@ -1,5 +1,6 @@
-#include "xchain/contract.pb.h"
 #include "xchain/block.h"
+
+#include "xchain/contract.pb.h"
 
 namespace pb = xchain::contract::sdk;
 
@@ -19,6 +20,7 @@ void Block::init(const pb::Block& pbblock) {
     tx_count = pbblock.tx_count();
     in_trunk = pbblock.in_trunk();
     next_hash = pbblock.next_hash();
+    timestamp = pbblock.timestamp();
 
     for (int i = 0; i < pbblock.txids_size(); i++) {
         txids.emplace_back(pbblock.txids(i));
@@ -26,4 +28,3 @@ void Block::init(const pb::Block& pbblock) {
 }
 
 }  // namespace xchain
-

--- a/src/xchain/block.h
+++ b/src/xchain/block.h
@@ -4,8 +4,10 @@
 namespace xchain {
 namespace contract {
 namespace sdk {
-    class Block;
-}}}
+class Block;
+}
+}  // namespace contract
+}  // namespace xchain
 
 namespace xchain {
 
@@ -26,6 +28,7 @@ public:
     int32_t tx_count;
     bool in_trunk;
     std::string next_hash;
+    int64_t timestamp;
 };
 }  // namespace xchain
 

--- a/src/xchain/contract.pb.cc
+++ b/src/xchain/contract.pb.cc
@@ -10664,6 +10664,7 @@ const int Block::kProposerFieldNumber;
 const int Block::kSignFieldNumber;
 const int Block::kPubkeyFieldNumber;
 const int Block::kHeightFieldNumber;
+const int Block::kTimestampFieldNumber;
 const int Block::kTxidsFieldNumber;
 const int Block::kTxCountFieldNumber;
 const int Block::kInTrunkFieldNumber;
@@ -10864,6 +10865,13 @@ const char* Block::_InternalParse(const char* begin, const char* end, void* obje
         GOOGLE_PROTOBUF_PARSER_ASSERT(ptr);
         break;
       }
+      // int64 timestamp = 10;
+      case 10: {
+        if (static_cast<::google::protobuf::uint8>(tag) != 80) goto handle_unusual;
+        msg->set_timestamp(::google::protobuf::internal::ReadVarint(&ptr));
+        GOOGLE_PROTOBUF_PARSER_ASSERT(ptr);
+        break;
+      }
       // repeated string txids = 11;
       case 11: {
         if (static_cast<::google::protobuf::uint8>(tag) != 90) goto handle_unusual;
@@ -11033,6 +11041,19 @@ bool Block::MergePartialFromCodedStream(
         break;
       }
 
+      // int64 timestamp = 10;
+      case 10: {
+        if (static_cast< ::google::protobuf::uint8>(tag) == (80 & 0xFF)) {
+
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &timestamp_)));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
       // repeated string txids = 11;
       case 11: {
         if (static_cast< ::google::protobuf::uint8>(tag) == (90 & 0xFF)) {
@@ -11164,6 +11185,11 @@ void Block::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt64(9, this->height(), output);
   }
 
+  // int64 timestamp = 10;
+  if (this->timestamp() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(10, this->timestamp(), output);
+  }
+
   // repeated string txids = 11;
   for (int i = 0, n = this->txids_size(); i < n; i++) {
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
@@ -11266,6 +11292,13 @@ size_t Block::ByteSizeLong() const {
         this->height());
   }
 
+  // int64 timestamp = 10;
+  if (this->timestamp() != 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::Int64Size(
+        this->timestamp());
+  }
+
   // int32 tx_count = 12;
   if (this->tx_count() != 0) {
     total_size += 1 +
@@ -11323,6 +11356,9 @@ void Block::MergeFrom(const Block& from) {
   if (from.height() != 0) {
     set_height(from.height());
   }
+  if (from.timestamp() != 0) {
+    set_timestamp(from.timestamp());
+  }
   if (from.tx_count() != 0) {
     set_tx_count(from.tx_count());
   }
@@ -11363,6 +11399,7 @@ void Block::InternalSwap(Block* other) {
   next_hash_.Swap(&other->next_hash_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   swap(height_, other->height_);
+  swap(timestamp_, other->timestamp_);
   swap(tx_count_, other->tx_count_);
   swap(in_trunk_, other->in_trunk_);
 }

--- a/src/xchain/contract.pb.h
+++ b/src/xchain/contract.pb.h
@@ -4601,6 +4601,12 @@ class Block :
   ::google::protobuf::int64 height() const;
   void set_height(::google::protobuf::int64 value);
 
+  // int64 timestamp = 10;
+  void clear_timestamp();
+  static const int kTimestampFieldNumber = 10;
+  ::google::protobuf::int64 timestamp() const;
+  void set_timestamp(::google::protobuf::int64 value);
+
   // int32 tx_count = 12;
   void clear_tx_count();
   static const int kTxCountFieldNumber = 12;
@@ -4626,6 +4632,7 @@ class Block :
   ::google::protobuf::internal::ArenaStringPtr pubkey_;
   ::google::protobuf::internal::ArenaStringPtr next_hash_;
   ::google::protobuf::int64 height_;
+  ::google::protobuf::int64 timestamp_;
   ::google::protobuf::int32 tx_count_;
   bool in_trunk_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
@@ -8819,6 +8826,20 @@ inline void Block::set_height(::google::protobuf::int64 value) {
   
   height_ = value;
   // @@protoc_insertion_point(field_set:xchain.contract.sdk.Block.height)
+}
+
+// int64 timestamp = 10;
+inline void Block::clear_timestamp() {
+  timestamp_ = PROTOBUF_LONGLONG(0);
+}
+inline ::google::protobuf::int64 Block::timestamp() const {
+  // @@protoc_insertion_point(field_get:xchain.contract.sdk.Block.timestamp)
+  return timestamp_;
+}
+inline void Block::set_timestamp(::google::protobuf::int64 value) {
+  
+  timestamp_ = value;
+  // @@protoc_insertion_point(field_set:xchain.contract.sdk.Block.timestamp)
 }
 
 // repeated string txids = 11;


### PR DESCRIPTION
## Description

add  timestamp field in query_block result.

see [PR](https://github.com/xuperchain/xupercore/pull/226) for more details

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

