### PR TITLE
add include file file to block

### DIFF
--- a/src/xchain/block.h
+++ b/src/xchain/block.h
@@ -1,7 +1,9 @@
 #ifndef XCHAIN_BLOCK_H
 #define XCHAIN_BLOCK_H
+
 #include <string>
 #include <vector>
+
 namespace xchain {
 namespace contract {
 namespace sdk {

--- a/src/xchain/block.h
+++ b/src/xchain/block.h
@@ -1,6 +1,7 @@
 #ifndef XCHAIN_BLOCK_H
 #define XCHAIN_BLOCK_H
-
+#include <string>
+#include <vector>
 namespace xchain {
 namespace contract {
 namespace sdk {


### PR DESCRIPTION
## Description

  absence of standard library file include causes compile errr for some version of emcc, include related file.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
