### PR TITLE
add standard library cache to accelerate build

### DIFF
--- a/scripts/emcc.Dockerfile
+++ b/scripts/emcc.Dockerfile
@@ -34,6 +34,7 @@ ENV EM_CACHE=/data/apps/emcc/emsdk/emscripten/1.38.30/cache
 ENV EMSCRIPTEN=/data/apps/emcc/emsdk/emscripten/1.38.30
 ENV BINARYEN_ROOT=/data/apps/emcc/emsdk/binaryen/tag-1.38.30_64bit_binaryen
 
+
 # 安装 protobuf
 RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-cpp-3.7.1.tar.gz
 RUN tar xvf protobuf-cpp-3.7.1.tar.gz
@@ -47,3 +48,9 @@ COPY src src
 COPY xdev.toml xdev.toml
 
 RUN mkdir lib && XEDV_ROOT=`pwd` bin/xdev build -o lib/libxchain.a --compiler host --using-precompiled-sdk=false -s "xchain" -s "xchain/trust_operators"
+
+
+COPY example example
+RUN  bin/xdev build -o example/counter.wasm  --compiler host example/counter.cc
+
+RUN chmod 777 -R /data/apps/emcc/emsdk/emscripten/1.38.30/


### PR DESCRIPTION
## Description

- fix permission error when build contract  using non-root  user. see makeUsingDocker function in [xdev](https://github.com/xuperchain/xdev/blob/main/mkfile/runner.go) for more details.
- cache standard build result in docker image build process to accelerate contract build 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

Please describe your solution to solve the issue or feature request.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
