### PR TITLE
bugfix: fix value type error in contract example source_trace

### DIFF
--- a/example/source_trace.cc
+++ b/example/source_trace.cc
@@ -93,7 +93,7 @@ public:
         std::string goodsRecordsKey = GOODSRECORD + id + "_0";
         std::string goodsRecordsTopKey = GOODSRECORDTOP + id;
         ctx->put_object(goodsRecordsKey, CREATE);
-        ctx->put_object(goodsRecordsTopKey, 0);
+        ctx->put_object(goodsRecordsTopKey, "0");
         ctx->ok(id);
     }
 


### PR DESCRIPTION
## Description

value of put should be string rather than int, error put will cause put nil error 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Brief of your solution

Please describe your solution to solve the issue or feature request.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
