### PR TITLE
emcc: add base image build args in dockerfile for different build situation

### DIFF
--- a/scripts/emcc.Dockerfile
+++ b/scripts/emcc.Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.14 AS builder
+ARG BASE_IMAGE_GO=golang:1.14
+ARG BASE_IMAGE_UBUNTU=ubuntu:18.04
+
+FROM $BASE_IMAGE_GO AS builder
 RUN apt-get update && apt-get install git
 
 RUN git clone https://github.com/xuperchain/xdev.git /data/apps/xdev
@@ -6,8 +9,12 @@ WORKDIR /data/apps/xdev
 
 RUN make build
 
+
 # ---
-FROM ubuntu:18.04
+ARG BASE_IMAGE_GO=golang:1.14
+ARG BASE_IMAGE_UBUNTU=ubuntu:18.04
+
+FROM $BASE_IMAGE_UBUNTU
 SHELL ["/bin/bash", "-c"]
 
 


### PR DESCRIPTION
## Description
add base image build args in dockerfile for different build situation
users can specify base image when run `docker build `

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Brief of your solution

Please describe your solution to solve the issue or feature request.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
